### PR TITLE
FIX: Compute topic title correctly

### DIFF
--- a/assets/javascripts/discourse/components/docs-topic.js.es6
+++ b/assets/javascripts/discourse/components/docs-topic.js.es6
@@ -1,11 +1,19 @@
 import Component from "@ember/component";
 import { reads } from "@ember/object/computed";
 import { computed } from "@ember/object";
+import discourseComputed from "discourse-common/utils/decorators";
 
 export default Component.extend({
   classNames: "docs-topic",
 
   originalPostContent: reads("post.cooked"),
+
+  title: computed("topic", function() {
+    const topic = this.topic;
+    if (topic) {
+      return topic.unicode_title || topic.title;
+    }
+  }),
 
   post: computed("topic", function () {
     return this.store.createRecord(

--- a/assets/javascripts/discourse/components/docs-topic.js.es6
+++ b/assets/javascripts/discourse/components/docs-topic.js.es6
@@ -7,13 +7,6 @@ export default Component.extend({
 
   originalPostContent: reads("post.cooked"),
 
-  title: computed("topic", function () {
-    const topic = this.topic;
-    if (topic) {
-      return topic.unicode_title || topic.title;
-    }
-  }),
-
   post: computed("topic", function () {
     return this.store.createRecord(
       "post",

--- a/assets/javascripts/discourse/components/docs-topic.js.es6
+++ b/assets/javascripts/discourse/components/docs-topic.js.es6
@@ -1,7 +1,6 @@
 import Component from "@ember/component";
 import { reads } from "@ember/object/computed";
 import { computed } from "@ember/object";
-import discourseComputed from "discourse-common/utils/decorators";
 
 export default Component.extend({
   classNames: "docs-topic",

--- a/assets/javascripts/discourse/components/docs-topic.js.es6
+++ b/assets/javascripts/discourse/components/docs-topic.js.es6
@@ -7,7 +7,7 @@ export default Component.extend({
 
   originalPostContent: reads("post.cooked"),
 
-  title: computed("topic", function() {
+  title: computed("topic", function () {
     const topic = this.topic;
     if (topic) {
       return topic.unicode_title || topic.title;

--- a/assets/javascripts/discourse/templates/components/docs-topic.hbs
+++ b/assets/javascripts/discourse/templates/components/docs-topic.hbs
@@ -5,7 +5,7 @@
 }}
 
 <div class="topic-content">
-  <h1>{{topic.unicode_title}}</h1>
+  <h1>{{title}}</h1>
   {{mount-widget
     widget="post"
     model=model

--- a/assets/javascripts/discourse/templates/components/docs-topic.hbs
+++ b/assets/javascripts/discourse/templates/components/docs-topic.hbs
@@ -5,7 +5,7 @@
 }}
 
 <div class="topic-content">
-  <h1>{{title}}</h1>
+  <h1>{{{topic.fancyTitle}}}</h1>
   {{mount-widget
     widget="post"
     model=model


### PR DESCRIPTION
Was using `unicode_title` but not all topics return a unicode_title
attribute. So need to instead do this.