### PR TITLE
FIX: Back button out of alignment

### DIFF
--- a/assets/stylesheets/common/docs.scss
+++ b/assets/stylesheets/common/docs.scss
@@ -165,6 +165,7 @@
         color: $tertiary;
         display: inline-flex;
         font-size: $font-down-1;
+        justify-content: normal;
         padding: 0;
         &::before {
           content: "«";


### PR DESCRIPTION
Core made buttons to use flexbox recently, which changed the behavior of
the go back button on Docs topics. The local justify-content declaration
overrides the core declaration causing problems.