### PR TITLE
FEATURE: Make Docs compatible with inline oneboxes

### DIFF
--- a/app/controllers/docs/docs_controller.rb
+++ b/app/controllers/docs/docs_controller.rb
@@ -35,6 +35,7 @@ module Docs
 
       respond_to do |format|
         format.html do
+          @title = set_title
           render :get_topic
         end
 
@@ -51,6 +52,15 @@ module Docs
       guardian = Guardian.new(current_user)
 
       TopicViewSerializer.new(topic_view, scope: guardian, root: false)
+    end
+
+    def set_title
+      title = "#{I18n.t('js.docs.title')} - #{SiteSetting.title}"
+      if @topic
+        topic_title = @topic['unicode_title'] || @topic['title']
+        title = "#{topic_title} - #{title}"
+      end
+      title
     end
 
     def topic_in_docs(category, tags)

--- a/app/views/docs/docs/get_topic.html.erb
+++ b/app/views/docs/docs/get_topic.html.erb
@@ -1,3 +1,5 @@
 <% content_for :head do %>
   <%= raw crawlable_meta_data(title: @topic["title"], description: @excerpt, ignore_canonical: true) if @topic %>
 <% end %>
+
+<% content_for(:title) { @title } %>


### PR DESCRIPTION
Linking directly to a Docs item like so `http://localhost:3000/docs?topic=16` would result in a generic inline onebox link. This adds logic to the Rails view so a proper title is rendered when the `InlineOneboxer` in core queries the route.