### PR TITLE
UX: Fix two small mobile styling issues

### DIFF
--- a/assets/stylesheets/common/docs.scss
+++ b/assets/stylesheets/common/docs.scss
@@ -149,6 +149,7 @@
       color: var(--tertiary, $tertiary);
       cursor: pointer;
       display: inline-block;
+      word-break: break-word;
       & > * {
         pointer-events: none;
       }

--- a/assets/stylesheets/mobile/docs.scss
+++ b/assets/stylesheets/mobile/docs.scss
@@ -14,6 +14,7 @@
       }
     }
     .docs-browse {
+      padding-bottom: 60px; // for DiscourseHub footer nav
       .docs-items {
         padding-right: 0;
       }


### PR DESCRIPTION
- adds bottom padding on mobile to avoid items staying hidden below the footer nav in DiscourseHub
- break words in titles so the list doesn't expand the width of the container due to a long space-less title (esp on mobile)