### PR TITLE
DEV: Add parameter to plugin outlet

### DIFF
--- a/assets/javascripts/discourse/templates/docs.hbs
+++ b/assets/javascripts/discourse/templates/docs.hbs
@@ -1,5 +1,5 @@
 <div class="docs">
-  {{plugin-outlet name="before-docs-search" args=(hash selectCategory=(action "updateSelectedCategories"))}}
+  {{plugin-outlet name="before-docs-search" args=(hash selectCategory=(action "updateSelectedCategories") tags=indexController.tags )}}
   {{docs-search
     searchTerm=(readonly indexController.searchTerm)
     onSearch=(action "performSearch")


### PR DESCRIPTION
This adds a parameters to the args hash of the `before-docs-search` plugin outlet so we can access tags via theme components using this outlet.