### PR TITLE
DEV: Compatibility with Discourse on Rails 6.1

### DIFF
--- a/lib/docs/query.rb
+++ b/lib/docs/query.rb
@@ -95,9 +95,9 @@ module Docs
         INNER JOIN topic_tags ttx ON ttx.topic_id = topics.id
         INNER JOIN tags t2 ON t2.id = ttx.tag_id
       SQL
-      tags = count_query.group('t2.name').count
+      tags = count_query.group('t2.name').reorder('').count
       tags = create_tags_object(tags)
-      categories = results.where('topics.category_id IS NOT NULL').group('topics.category_id').count
+      categories = results.where('topics.category_id IS NOT NULL').group('topics.category_id').reorder('').count
       categories = create_categories_object(categories)
 
       results_length = results.size


### PR DESCRIPTION
Related to https://github.com/discourse/discourse/pull/12688.

The tags and categories count queries are failing on Rails 6.1 with `ERROR:  column "topics.bumped_at" must appear in the GROUP BY clause or be used in an aggregate function`. The reason these queries didn't fail prior to 6.1 was because Active Record would automatically drop the `ORDER BY` clause from the queries when we called `count` on them. This behavior has been [changed](https://github.com/rails/rails/commit/5812feffe321f18e244f212abfe884ad83215554) in 6.1 so now Active Record only drops the `ORDER BY` clause if there is no `GROUP BY` clause. Our queries do have `GROUP BY` clauses, so we need to drop the `ORDER BY` clauses ourselves before we call `count` to make them work on 6.1.