### PR TITLE
FIX: ignore category filter when incorrect param

### DIFF
--- a/lib/docs/query.rb
+++ b/lib/docs/query.rb
@@ -27,7 +27,8 @@ module Docs
 
       # filter results by selected category
       if @filters[:category].present?
-        results = results.where('topics.category_id IN (?)', @filters[:category].split('|'))
+        category_ids = @filters[:category].split('|')
+        results = results.where('topics.category_id IN (?)', category_ids) if category_ids.all? { |id| id =~ /\A\d+\z/ }
       end
 
       # filter results by selected tags

--- a/spec/requests/docs_controller_spec.rb
+++ b/spec/requests/docs_controller_spec.rb
@@ -120,6 +120,20 @@ describe Docs::DocsController do
         expect(categories.size).to eq(1)
         expect(topics.size).to eq(1)
       end
+
+      it 'ignores category filter when incorrect argument' do
+        get "/docs.json?category=hack"
+
+        expect(response.status).to eq(200)
+
+        json = JSON.parse(response.body)
+        categories = json['categories']
+        topics = json['topics']['topic_list']['topics']
+
+        expect(categories.size).to eq(2)
+        expect(topics.size).to eq(3)
+
+      end
     end
 
     context 'when ordering results' do


### PR DESCRIPTION
Category filter accepts ids of categories. If value is manipulated, we should ignore it.