### PR TITLE
DEV: Add outlet + scroll event to support DiscoTOC

### DIFF
--- a/assets/javascripts/discourse/components/docs-topic.js.es6
+++ b/assets/javascripts/discourse/components/docs-topic.js.es6
@@ -1,18 +1,16 @@
 import Component from "@ember/component";
 import { reads } from "@ember/object/computed";
-import computed from "discourse-common/utils/decorators";
+import computed, { bind } from "discourse-common/utils/decorators";
+import discourseDebounce from "discourse-common/lib/debounce";
 
 export default Component.extend({
   classNames: "docs-topic",
 
   originalPostContent: reads("post.cooked"),
 
-  @computed("topic")
-  post() {
-    return this.store.createRecord(
-      "post",
-      this.topic.post_stream.posts.firstObject
-    );
+  @computed("topic.post_stream")
+  post(stream) {
+    return this.store.createRecord("post", stream?.posts.firstObject);
   },
 
   @computed("post", "topic")
@@ -26,15 +24,27 @@ export default Component.extend({
     return post;
   },
 
+  @bind
+  _emitScrollEvent() {
+    this.appEvents.trigger("docs-topic:current-post-scrolled");
+  },
+
+  @bind
+  debounceScrollEvent() {
+    discourseDebounce(this, this._emitScrollEvent, 200);
+  },
+
   didInsertElement() {
     this._super(...arguments);
 
     document.querySelector("body").classList.add("archetype-docs-topic");
+    document.addEventListener("scroll", this.debounceScrollEvent);
   },
 
   willDestroyElement() {
     this._super(...arguments);
 
     document.querySelector("body").classList.remove("archetype-docs-topic");
+    document.removeEventListener("scroll", this.debounceScrollEvent);
   },
 });

--- a/assets/javascripts/discourse/templates/docs-index.hbs
+++ b/assets/javascripts/discourse/templates/docs-index.hbs
@@ -88,6 +88,7 @@
       {{#if selectedTopic}}
         {{#conditional-loading-spinner condition=isTopicLoading}}
           {{docs-topic topic=topic return=(action "returnToList")}}
+          {{plugin-outlet name="below-docs-topic" tagName="" connectorTagName="div"}}
         {{/conditional-loading-spinner}}
       {{else}}
         <div class="docs-results">


### PR DESCRIPTION
- adds a new `below-docs-topic` outlet
- emits a `docs-topic:current-post-scrolled` event that can be consumed by other plugins (DiscoTOC will use this to calculate the scroll position of the active heading)
- fixes an unrelated bug that would result in `TypeError: undefined is not an object (evaluating 'this.topic.post_stream.posts')` console errors