### PR TITLE
FIX: TopicViewItem and TopicUser for doc topics

### DIFF
--- a/app/controllers/docs/docs_controller.rb
+++ b/app/controllers/docs/docs_controller.rb
@@ -51,7 +51,17 @@ module Docs
       topic_view = TopicView.new(topic.id, current_user)
       guardian = Guardian.new(current_user)
 
+      ip = request.remote_ip
+      user_id = (current_user.id if current_user)
+      track_visit = should_track_visit_to_topic?
+
+      TopicsController.defer_track_visit(topic.id, ip, user_id, track_visit)
+
       TopicViewSerializer.new(topic_view, scope: guardian, root: false)
+    end
+
+    def should_track_visit_to_topic?
+      !!((!request.format.json? || params[:track_visit]) && current_user)
     end
 
     def set_title

--- a/assets/javascripts/discourse/models/docs.js.es6
+++ b/assets/javascripts/discourse/models/docs.js.es6
@@ -31,6 +31,7 @@ Docs.reopenClass({
     }
     if (params.selectedTopic) {
       filters.push(`topic=${params.selectedTopic}`);
+      filters.push("track_visit=true");
     }
 
     return ajax(`/docs.json?${filters.join("&")}`).then((data) => {

--- a/spec/requests/docs_controller_spec.rb
+++ b/spec/requests/docs_controller_spec.rb
@@ -265,6 +265,26 @@ describe Docs::DocsController do
 
         expect(response.parsed_body['topic']['id']).to eq(topic.id)
       end
+
+      it 'should create TopicViewItem' do
+        admin = Fabricate(:admin)
+        sign_in(admin)
+        expect do
+          get "/docs.json?topic=#{topic.id}"
+        end.to change { TopicViewItem.count }.by(1)
+      end
+
+      it 'should create TopicUser if authenticated' do
+        expect do
+          get "/docs.json?topic=#{topic.id}&track_visit=true"
+        end.not_to change { TopicUser.count }
+
+        admin = Fabricate(:admin)
+        sign_in(admin)
+        expect do
+          get "/docs.json?topic=#{topic.id}&track_visit=true"
+        end.to change { TopicUser.count }.by(1)
+      end
     end
   end
 end


### PR DESCRIPTION
When a documentation topic is viewed, corresponding TopicViewItem and TopicUser should be created.

A method from a TopicController is called to avoid duplication. Added specs should warn us if ever that core method would change.