### PR TITLE
DEV: add plugin outlet to enable custom checkbox css

### DIFF
--- a/assets/javascripts/discourse/templates/docs-index.hbs
+++ b/assets/javascripts/discourse/templates/docs-index.hbs
@@ -22,7 +22,7 @@
                   checked=(readonly filterSolved)
                   change=(action "onChangeFilterSolved" value="target.checked")
                 }}
-                {{plugin-outlet name="custom-checkbox" tagName="" connectorTagName="span"}}
+                {{plugin-outlet name="custom-checkbox"}}
                 {{i18n "docs.filter_solved"}}
               </label>
             </div>

--- a/assets/javascripts/discourse/templates/docs-index.hbs
+++ b/assets/javascripts/discourse/templates/docs-index.hbs
@@ -22,6 +22,7 @@
                   checked=(readonly filterSolved)
                   change=(action "onChangeFilterSolved" value="target.checked")
                 }}
+                {{plugin-outlet name="custom-checkbox" tagName="" connectorTagName="span"}}
                 {{i18n "docs.filter_solved"}}
               </label>
             </div>


### PR DESCRIPTION
This plugin outlet will allow developers to insert a HTML element so they can create a custom checkbox using a sibling selector (before/after psudos do not work directly on inputs). 

(using this for a customer theme)