### PR TITLE
DEV: update routing to allow for open_in_new_tab

### DIFF
--- a/assets/javascripts/discourse/components/docs-topic-list.js
+++ b/assets/javascripts/discourse/components/docs-topic-list.js
@@ -15,15 +15,6 @@ export default Component.extend({
     return order === "activity";
   },
 
-  // need to handle clicks here since links are in a raw view
-  click(e) {
-    if (e.target.classList.contains("docs-topic-link")) {
-      const topicId = e.target.dataset.topicId;
-      this.selectTopic(topicId);
-      return false;
-    }
-  },
-
   @action
   sortListActivity() {
     this.sortBy("activity");

--- a/assets/javascripts/discourse/controllers/docs-index.js
+++ b/assets/javascripts/discourse/controllers/docs-index.js
@@ -264,13 +264,6 @@ export default Controller.extend({
   },
 
   @action
-  setSelectedTopic(topicId) {
-    this.set("selectedTopic", topicId);
-
-    window.scrollTo(0, 0);
-  },
-
-  @action
   onChangeFilterSolved(solvedFilter) {
     this.set("filterSolved", solvedFilter);
   },

--- a/assets/javascripts/discourse/templates/docs-index.hbs
+++ b/assets/javascripts/discourse/templates/docs-index.hbs
@@ -117,7 +117,6 @@
               ascending=ascending
               order=orderColumn
               sortBy=(action "sortBy")
-              selectTopic=(action "setSelectedTopic")
               loadMore=(action "loadMore")
               loading=isLoadingMore
             }}

--- a/assets/javascripts/discourse/templates/docs-topic-link.hbr
+++ b/assets/javascripts/discourse/templates/docs-topic-link.hbr
@@ -1,1 +1,1 @@
-<a data-topic-id="{{topic.id}}" class="docs-topic-link">{{{topic.fancyTitle}}}</a>
+<a href="/docs?topic={{topic.id}}" class="docs-topic-link">{{{topic.fancyTitle}}}</a>


### PR DESCRIPTION
We can rip out the `click` handler completely and just lean on the _logic_ we have in `docs-index`. 

https://github.com/discourse/discourse-docs/blob/0cef82aec0abcf500affa80e16b8696dfee708e0/assets/javascripts/discourse/routes/docs-index.js#L12

It will always refresh the `selectedTopic` so there will be no need to update it within the click handler. Which then nullifies the need for `setSelectedTopic`.