### PR TITLE
DEV: Remove 'htmlSafe' string prototype extensions

### DIFF
--- a/assets/javascripts/discourse/controllers/docs-index.js
+++ b/assets/javascripts/discourse/controllers/docs-index.js
@@ -6,6 +6,7 @@ import Docs from "discourse/plugins/discourse-docs/discourse/models/docs";
 import { getOwner } from "@ember/application";
 import getURL from "discourse-common/lib/get-url";
 import I18n from "I18n";
+import { htmlSafe } from "@ember/template";
 
 const SHOW_FILTER_AT = 10;
 
@@ -213,7 +214,7 @@ export default Controller.extend({
 
     return {
       title: I18n.t("docs.no_docs.title"),
-      body: body.htmlSafe(),
+      body: htmlSafe(body),
     };
   },
 


### PR DESCRIPTION
## Ember Upgrade

Context: https://deprecations.emberjs.com/v3.x/#toc_ember-string-prototype_extensions