### PR TITLE
DEV: Fix failing test if sidebar is enabled by default

### DIFF
--- a/test/javascripts/acceptance/docs-test.js
+++ b/test/javascripts/acceptance/docs-test.js
@@ -15,6 +15,7 @@ acceptance("Docs", function (needs) {
   needs.site({ docs_path: DOCS_URL_PATH });
   needs.settings({
     docs_enabled: true,
+    navigation_menu: "legacy",
   });
 
   needs.pretender((server, helper) => {


### PR DESCRIPTION
This PR https://github.com/discourse/discourse/pull/19406 enables the
sidebar on by default, so we need to set the sidebar to legacy like the
original test assumed.
