### PR TITLE
UX: Hide non-functional revision history button

### DIFF
--- a/assets/stylesheets/common/docs.scss
+++ b/assets/stylesheets/common/docs.scss
@@ -205,6 +205,10 @@
     #share-link .reply-as-new-topic {
       display: none;
     }
+
+    .post-info.edits {
+      display: none;
+    }
   }
 }
 


### PR DESCRIPTION
This button doesn't work in the docs topic view. The docs plugin has deliberately disabled other forms of interactivity on posts (e.g. reply/edit/quote), so it makes sense to hide this as well.

https://meta.discourse.org/t/discourse-docs-topics-edit-history-modal-does-not-open-on-click/260285/4?u=david