### PR TITLE
FIX: Icons not appearing

### DIFF
--- a/assets/javascripts/discourse/templates/docs-index.hbs
+++ b/assets/javascripts/discourse/templates/docs-index.hbs
@@ -44,7 +44,7 @@
                       "categories-alphabet active"
                       "categories-alphabet"
                     }}
-                    @icon="categorySortAlphaIcon"
+                    @icon={{this.categorySortAlphaIcon}}
                     @action={{toggleCategorySort}}
                     @actionParam="alpha"
                   />
@@ -54,7 +54,7 @@
                       "categories-amount active"
                       "categories-amount"
                     }}
-                    @icon="categorySortNumericIcon"
+                    @icon={{this.categorySortNumericIcon}}
                     @action={{toggleCategorySort}}
                     @actionParam="numeric"
                   />
@@ -94,7 +94,7 @@
                       "tags-alphabet active"
                       "tags-alphabet"
                     }}
-                    @icon="tagSortAlphaIcon"
+                    @icon={{this.tagSortAlphaIcon}}
                     @action={{toggleTagSort}}
                     @actionParam="alpha"
                   />
@@ -104,7 +104,7 @@
                       "tags-amount active"
                       "tags-amount"
                     }}
-                    @icon="tagSortNumericIcon"
+                    @icon={{this.tagSortNumericIcon}}
                     @action={{toggleTagSort}}
                     @actionParam="numeric"
                   />


### PR DESCRIPTION
**This PR fixes a regression causing the icons in the sidebar to not render.**

---

**Before:**
<img width="269" alt="Screenshot 2023-05-10 at 12 46 32" src="https://github.com/discourse/discourse-docs/assets/30090424/5c7ede32-aa72-450a-8260-7ffd9bc73435">
<img width="265" alt="Screenshot 2023-05-10 at 12 46 39" src="https://github.com/discourse/discourse-docs/assets/30090424/1dcdd2d1-8b0a-4d34-bdfa-9ac21910e5df">

**After:**
<img width="219" alt="Screenshot 2023-05-10 at 12 46 44" src="https://github.com/discourse/discourse-docs/assets/30090424/05bbd0c0-52bc-4f5f-9233-81023140dbae">
<img width="218" alt="Screenshot 2023-05-10 at 12 46 50" src="https://github.com/discourse/discourse-docs/assets/30090424/0fbf0ec0-7f86-48c4-bee7-3462bec62bd0">
