### PR TITLE
FIX: Incorrect plugin name in `requires_plugin`

### DIFF
--- a/app/controllers/docs/docs_controller.rb
+++ b/app/controllers/docs/docs_controller.rb
@@ -2,7 +2,7 @@
 
 module Docs
   class DocsController < ApplicationController
-    requires_plugin "docs"
+    requires_plugin PLUGIN_NAME
 
     skip_before_action :check_xhr, only: [:index]
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -23,7 +23,7 @@ load File.expand_path("lib/docs/query.rb", __dir__)
 
 GlobalSetting.add_default :docs_path, "docs"
 
-module ::DiscourseDocs
+module ::Docs
   PLUGIN_NAME = "discourse-docs"
 end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -23,6 +23,10 @@ load File.expand_path("lib/docs/query.rb", __dir__)
 
 GlobalSetting.add_default :docs_path, "docs"
 
+module ::DiscourseDocs
+  PLUGIN_NAME = "discourse-docs"
+end
+
 after_initialize do
   require_dependency "search"
 


### PR DESCRIPTION
This resulted in `Required plugin 'docs' not found` warnings in logs