### PR TITLE
FEATURE: add local onebox handler for /docs urls

### DIFF
--- a/app/controllers/docs/docs_controller.rb
+++ b/app/controllers/docs/docs_controller.rb
@@ -47,7 +47,7 @@ module Docs
     end
 
     def get_topic(topic, current_user)
-      return nil unless topic_in_docs(topic.category_id, topic.tags)
+      return nil unless Docs.topic_in_docs(topic.category_id, topic.tags)
 
       topic_view = TopicView.new(topic.id, current_user)
       guardian = Guardian.new(current_user)
@@ -72,14 +72,6 @@ module Docs
         title = "#{topic_title} - #{title}"
       end
       title
-    end
-
-    def topic_in_docs(category, tags)
-      category_match = Docs::Query.categories.include?(category.to_s)
-      tags = tags.pluck(:name)
-      tag_match = Docs::Query.tags.any? { |tag| tags.include?(tag) }
-
-      category_match || tag_match
     end
   end
 end

--- a/lib/docs/engine.rb
+++ b/lib/docs/engine.rb
@@ -11,4 +11,21 @@ module ::Docs
       end
     end
   end
+
+  def self.onebox_template
+    @onebox_template ||=
+      begin
+        path =
+          "#{Rails.root}/plugins/discourse-docs/lib/onebox/templates/discourse_docs_list.mustache"
+        File.read(path)
+      end
+  end
+
+  def self.topic_in_docs(category, tags)
+    category_match = Docs::Query.categories.include?(category.to_s)
+    tags = tags.pluck(:name)
+    tag_match = Docs::Query.tags.any? { |tag| tags.include?(tag) }
+
+    category_match || tag_match
+  end
 end

--- a/lib/onebox/templates/discourse_docs_list.mustache
+++ b/lib/onebox/templates/discourse_docs_list.mustache
@@ -1,0 +1,7 @@
+<aside class="onebox docs-onebox">
+  <article class="onebox-body docs-onebox-body">
+    <h3>
+      <a href="{{url}}">{{{name}}}</a>
+    </h3>
+  </article>
+</aside>

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Docs do
+  fab!(:category) { Fabricate(:category) }
+  fab!(:topic) { Fabricate(:topic, category: category) }
+  fab!(:post) { Fabricate(:post, topic: topic) }
+  fab!(:non_docs_category) { Fabricate(:category) }
+  fab!(:non_docs_topic) { Fabricate(:topic, category: non_docs_category) }
+  fab!(:non_docs_post) { Fabricate(:post, topic: non_docs_topic) }
+
+  before do
+    SiteSetting.docs_enabled = true
+    SiteSetting.docs_categories = category.id.to_s
+    GlobalSetting.stubs(:docs_path).returns("docs")
+  end
+
+  describe "docs oneboxes" do
+    let(:docs_list_url) { "#{Discourse.base_url}/#{GlobalSetting.docs_path}" }
+    let(:docs_topic_url) { "#{Discourse.base_url}/#{GlobalSetting.docs_path}?topic=#{topic.id}" }
+    let(:non_docs_topic_url) do
+      "#{Discourse.base_url}/#{GlobalSetting.docs_path}?topic=#{non_docs_topic.id}"
+    end
+
+    context "when inline" do
+      it "renders docs list" do
+        results = InlineOneboxer.new([docs_list_url], skip_cache: true).process
+        expect(results).to be_present
+        expect(results[0][:url]).to eq(docs_list_url)
+        expect(results[0][:title]).to eq(I18n.t("js.docs.title"))
+      end
+
+      it "renders docs topic" do
+        results = InlineOneboxer.new([docs_topic_url], skip_cache: true).process
+        expect(results).to be_present
+        expect(results[0][:url]).to eq(docs_topic_url)
+        expect(results[0][:title]).to eq(topic.title)
+      end
+
+      it "does not render topic if not in docs" do
+        results = InlineOneboxer.new([non_docs_topic_url], skip_cache: true).process
+        expect(results).to be_empty
+      end
+    end
+
+    context "when regular" do
+      it "renders docs list" do
+        onebox = Oneboxer.preview(docs_list_url)
+        expect(onebox).to match_html <<~HTML
+          <aside class="onebox docs-onebox">
+            <article class="onebox-body docs-onebox-body">
+              <h3>
+                <a href="#{docs_list_url}">#{I18n.t("js.docs.title")}</a>
+              </h3>
+            </article>
+          </aside>
+        HTML
+      end
+
+      it "renders docs topic" do
+        onebox = Oneboxer.preview(docs_topic_url)
+        expect(onebox).to include(%{data-topic="#{topic.id}">})
+        expect(onebox).to include(PrettyText.avatar_img(post.user.avatar_template_url, "tiny"))
+        expect(onebox).to include(%{<a href="#{docs_topic_url}">#{topic.title}</a>})
+        expect(onebox).to include(post.excerpt)
+      end
+
+      it "does not onebox topic if not in docs" do
+        onebox = Oneboxer.preview(non_docs_topic_url)
+        expect(onebox).to eq(%{<a href='#{non_docs_topic_url}'>#{non_docs_topic_url}</a>})
+      end
+    end
+  end
+end


### PR DESCRIPTION
Docs (`/docs`) links to the same Discourse instance weren't supported because there were no local Onebox handlers for these Docs URLs.

This PR adds local Oneboxer and InlineOneboxer handlers to support the Docs lists (any `/docs` URL without a `topic` query param) and Docs topics (`/docs?topic=N`).

![Oneboxing Docs URLs](https://github.com/discourse/discourse-docs/assets/3530/a48b6b1e-a325-4b32-9963-f31d0f5f3280)

Docs lists are rendered as a generic Onebox with a `js.docs.title` title.

A Docs topic is rendered exactly like a non-Doc topic, with the OP avatar, category boxes, and excerpt, and it's also expandable.