### PR TITLE
DEV: Correct fixtures to avoid translations error

### DIFF
--- a/test/javascripts/acceptance/docs-user-status-test.js
+++ b/test/javascripts/acceptance/docs-user-status-test.js
@@ -24,6 +24,7 @@ acceptance("Docs - user status", function (needs) {
               id: 427,
               topic_id: 1,
               username: "admin1",
+              post_number: 2,
               cooked:
                 '<p>This is a document.</p>\n<p>I am mentioning another user <a class="mention" href="/u/andrei4">@andrei4</a></p>',
               mentioned_users: [


### PR DESCRIPTION
Why this change?

In Discourse core, we have made the change to raise an error when a
interpolation argument is missing when calling `I18n.translate` to help
catch regressions in the UI where we may end up displaying broken
translations.