### PR TITLE
FIX: Load complete category objects

### DIFF
--- a/assets/javascripts/discourse/models/docs.js
+++ b/assets/javascripts/discourse/models/docs.js
@@ -40,12 +40,10 @@ Docs.reopenClass({
 
     return ajax(`/${docsPath}.json?${filters.join("&")}`).then((data) => {
       const site = Site.current();
-      if (site.lazy_load_categories) {
-        data.categories?.forEach((category) => site.updateCategory(category));
-        data.topics.topic_list.categories?.forEach((category) =>
-          site.updateCategory(category)
-        );
-      }
+      data.categories?.forEach((category) => site.updateCategory(category));
+      data.topics.topic_list.categories?.forEach((category) =>
+        site.updateCategory(category)
+      );
       data.topics.topic_list.topics = data.topics.topic_list.topics.map(
         (topic) => Topic.create(topic)
       );
@@ -60,11 +58,9 @@ Docs.reopenClass({
   loadMore(loadMoreUrl) {
     return ajax(loadMoreUrl).then((data) => {
       const site = Site.current();
-      if (site.lazy_load_categories) {
-        data.topics.topic_list.categories?.forEach((category) =>
-          site.updateCategory(category)
-        );
-      }
+      data.topics.topic_list.categories?.forEach((category) =>
+        site.updateCategory(category)
+      );
       data.topics.topic_list.topics = data.topics.topic_list.topics.map(
         (topic) => Topic.create(topic)
       );

--- a/lib/docs/query.rb
+++ b/lib/docs/query.rb
@@ -230,14 +230,10 @@ module Docs
           count = category_counts[category.id]
           active = @filters[:category] && @filters[:category].include?(category.id.to_s)
 
-          if @guardian.can_lazy_load_categories?
-            BasicCategorySerializer
-              .new(categories[id], scope: @guardian, root: false)
-              .as_json
-              .merge(count:, active:)
-          else
-            { id: category.id, count:, active: }
-          end
+          BasicCategorySerializer
+            .new(category, scope: @guardian, root: false)
+            .as_json
+            .merge(count:, active:)
         end
         .sort_by { |category| [category[:active] ? 0 : 1, -category[:count]] }
     end

--- a/lib/docs/query.rb
+++ b/lib/docs/query.rb
@@ -225,24 +225,20 @@ module Docs
 
       Category.preload_user_fields!(@guardian, categories)
 
-      categories = categories.index_by(&:id)
-
-      categories_object = []
-
-      category_counts.each do |id, count|
+      categories.map do |category|
+        count = category_counts[category.id]
         active = @filters[:category] && @filters[:category].include?(id.to_s)
 
-        categories_object << if @guardian.can_lazy_load_categories?
+        if @guardian.can_lazy_load_categories?
           BasicCategorySerializer
             .new(categories[id], scope: @guardian, root: false)
             .as_json
-            .merge(id:, count:, active:)
+            .merge(count:, active:)
         else
-          category_object = { id:, count:, active: }
+          { id: category.id, count:, active: }
         end
       end
-
-      categories_object.sort_by { |category| [category[:active] ? 0 : 1, -category[:count]] }
+      .sort_by { |category| [category[:active] ? 0 : 1, -category[:count]] }
     end
 
     def load_more_url

--- a/lib/docs/query.rb
+++ b/lib/docs/query.rb
@@ -225,20 +225,21 @@ module Docs
 
       Category.preload_user_fields!(@guardian, categories)
 
-      categories.map do |category|
-        count = category_counts[category.id]
-        active = @filters[:category] && @filters[:category].include?(id.to_s)
+      categories
+        .map do |category|
+          count = category_counts[category.id]
+          active = @filters[:category] && @filters[:category].include?(category.id.to_s)
 
-        if @guardian.can_lazy_load_categories?
-          BasicCategorySerializer
-            .new(categories[id], scope: @guardian, root: false)
-            .as_json
-            .merge(count:, active:)
-        else
-          { id: category.id, count:, active: }
+          if @guardian.can_lazy_load_categories?
+            BasicCategorySerializer
+              .new(categories[id], scope: @guardian, root: false)
+              .as_json
+              .merge(count:, active:)
+          else
+            { id: category.id, count:, active: }
+          end
         end
-      end
-      .sort_by { |category| [category[:active] ? 0 : 1, -category[:count]] }
+        .sort_by { |category| [category[:active] ? 0 : 1, -category[:count]] }
     end
 
     def load_more_url

--- a/lib/docs/query.rb
+++ b/lib/docs/query.rb
@@ -222,7 +222,10 @@ module Docs
           )
           .joins("LEFT JOIN topics t on t.id = categories.topic_id")
           .select("categories.*, t.slug topic_slug")
-          .index_by(&:id)
+
+      Category.preload_user_fields!(@guardian, categories)
+
+      categories = categories.index_by(&:id)
 
       categories_object = []
 

--- a/spec/requests/docs_controller_spec.rb
+++ b/spec/requests/docs_controller_spec.rb
@@ -174,8 +174,8 @@ describe Docs::DocsController do
         topics = json["topics"]["topic_list"]["topics"]
 
         expect(categories.size).to eq(2)
-        expect(categories[0]).to eq({ "active" => true, "count" => 1, "id" => category2.id })
-        expect(categories[1]).to eq({ "active" => false, "count" => 2, "id" => category.id })
+        expect(categories[0]).to include({ "active" => true, "count" => 1, "id" => category2.id })
+        expect(categories[1]).to include({ "active" => false, "count" => 2, "id" => category.id })
         expect(topics.size).to eq(1)
       end
 


### PR DESCRIPTION
Not all categories are preloaded when lazy_load_categories is enabled. In this case, the category objects that are loaded through /docs.json must be complete.