### PR TITLE
DEV: Update defer_track_visit method in line with core

### DIFF
--- a/app/controllers/docs/docs_controller.rb
+++ b/app/controllers/docs/docs_controller.rb
@@ -55,9 +55,7 @@ module Docs
       ip = request.remote_ip
       user_id = (current_user.id if current_user)
 
-      # TODO (martin) Change this to `defer_track_visit` once the core
-      # method is renamed.
-      TopicsController.defer_track_visit_v2(topic.id, user_id) if should_track_visit_to_topic?
+      TopicsController.defer_track_visit(topic.id, user_id) if should_track_visit_to_topic?
       TopicsController.defer_topic_view(topic.id, ip, user_id)
 
       TopicViewSerializer.new(topic_view, scope: guardian, root: false)


### PR DESCRIPTION
When https://github.com/discourse/discourse/pull/27761 is
merged in core the v2 method name is obsolete and we
can call `defer_track_visit` once more.
