### PR TITLE
FIX: Don't error out on non-stringy tags parameter

### DIFF
--- a/app/controllers/docs/docs_controller.rb
+++ b/app/controllers/docs/docs_controller.rb
@@ -7,6 +7,10 @@ module Docs
     skip_before_action :check_xhr, only: [:index]
 
     def index
+      if params[:tags].is_a?(Array) || params[:tags].is_a?(ActionController::Parameters)
+        raise Discourse::InvalidParameters.new("Only strings are accepted for tag lists")
+      end
+
       filters = {
         topic: params[:topic],
         tags: params[:tags],

--- a/spec/requests/docs_controller_spec.rb
+++ b/spec/requests/docs_controller_spec.rb
@@ -106,6 +106,18 @@ describe Docs::DocsController do
         expect(topics.size).to eq(1)
       end
 
+      it "should not error out when tags is an array" do
+        get "/#{GlobalSetting.docs_path}.json?tags[]=test"
+
+        expect(response.status).to eq(400)
+      end
+
+      it "should not error out when tags is a nested parameter" do
+        get "/#{GlobalSetting.docs_path}.json?tags[foo]=test"
+
+        expect(response.status).to eq(400)
+      end
+
       context "when show_tags_by_group is enabled" do
         fab!(:tag4) { Fabricate(:tag, topics: [topic], name: "test4") }
 


### PR DESCRIPTION
### What is this change?

We're expecting the `tags` parameter to be a string. But the client can send an array or a nested parameter (thanks to the Rack protocol.) We're seeing exceptions in logs where the application is erroring out because of this.

### How does this fix it?

Raise a `Discourse::InvalidParameters` exception if we get a non-stringy `tags` parameter.