### PR TITLE
DEV: update deprecated icon names times-circle

### DIFF
--- a/assets/javascripts/discourse/components/docs-category.hbs
+++ b/assets/javascripts/discourse/components/docs-category.hbs
@@ -3,7 +3,7 @@
   {{action this.selectCategory}}
   class="docs-item docs-category {{if this.category.active 'selected'}}"
 >
-  {{d-icon (if this.category.active "times-circle" "far-circle")}}
+  {{d-icon (if this.category.active "circle-xmark" "far-circle")}}
 
   <span class="docs-item-id category-id">{{this.categoryName}}</span>
   <span class="docs-item-count category-count">{{this.category.count}}</span>


### PR DESCRIPTION
This PR updates the deprecated `times-circle` icon name. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.