### PR TITLE
DEV: Use `transformedPost` as args to the Post widget

### DIFF
--- a/assets/javascripts/discourse/components/docs-topic.js
+++ b/assets/javascripts/discourse/components/docs-topic.js
@@ -5,7 +5,6 @@ import { classNames } from "@ember-decorators/component";
 import discourseDebounce from "discourse/lib/debounce";
 import computed, { bind } from "discourse/lib/decorators";
 import transformPost from "discourse/lib/transform-post";
-import { currentUser } from "discourse/tests/helpers/qunit-helpers";
 
 @classNames("docs-topic")
 export default class DocsTopic extends Component {
@@ -15,7 +14,7 @@ export default class DocsTopic extends Component {
   @reads("post.cooked") originalPostContent;
 
   @computed("currentUser", "model")
-  post(stream) {
+  post() {
     return transformPost(this.currentUser, this.site, this.model);
   }
 

--- a/assets/javascripts/discourse/components/docs-topic.js
+++ b/assets/javascripts/discourse/components/docs-topic.js
@@ -1,21 +1,30 @@
 import Component from "@ember/component";
 import { reads } from "@ember/object/computed";
+import { service } from "@ember/service";
 import { classNames } from "@ember-decorators/component";
 import discourseDebounce from "discourse/lib/debounce";
 import computed, { bind } from "discourse/lib/decorators";
+import transformPost from "discourse/lib/transform-post";
+import { currentUser } from "discourse/tests/helpers/qunit-helpers";
 
 @classNames("docs-topic")
 export default class DocsTopic extends Component {
+  @service currentUser;
+  @service site;
+
   @reads("post.cooked") originalPostContent;
 
-  @computed("topic.post_stream")
+  @computed("currentUser", "model")
   post(stream) {
-    return this.store.createRecord("post", stream?.posts.firstObject);
+    return transformPost(this.currentUser, this.site, this.model);
   }
 
-  @computed("post", "topic")
+  @computed("topic", "topic.post_stream")
   model() {
-    const post = this.post;
+    const post = this.store.createRecord(
+      "post",
+      this.topic.post_stream?.posts.firstObject
+    );
 
     if (!post.topic) {
       post.set("topic", this.topic);


### PR DESCRIPTION
This is necessary due to upcoming changes in the post model for the Glimmer post stream.

The post widgets expect to receive a transformed post as argument and use the spread operator to pass attributes to the inner widget, however the Docs plugin was providing a post model instance as argument instead.

This used to work fine, but as we introduce tracked properties in the post model, the spread operator doesn't copy their values, which causes issues.

This PR changes the DocsTopic Component to provide a transformedPost as argument to the post widget instead.