### PR TITLE
DEV: docs index spec working with core themes

### DIFF
--- a/spec/system/docs_index_spec.rb
+++ b/spec/system/docs_index_spec.rb
@@ -51,7 +51,9 @@ describe "Discourse Docs | Index", type: :system do
 
     context "when the theme modifier serialize_topic_excerpts is true" do
       before do
-        ThemeModifierSet.find_by(theme_id: Theme.first.id).update!(serialize_topic_excerpts: true)
+        ThemeModifierSet.find_by(theme_id: SiteSetting.default_theme_id).update!(
+          serialize_topic_excerpts: true,
+        )
         Theme.clear_cache!
       end
 


### PR DESCRIPTION
With core themes, the first theme does not have to be the default one.

Correlated draft PR with core themes: https://github.com/discourse/discourse/pull/32681