### PR TITLE
DEV: Added compatibility with the Glimmer Post Stream

### DIFF
--- a/assets/javascripts/discourse/components/docs-topic.gjs
+++ b/assets/javascripts/discourse/components/docs-topic.gjs
@@ -5,6 +5,7 @@ import { classNames } from "@ember-decorators/component";
 import DButton from "discourse/components/d-button";
 import MountWidget from "discourse/components/mount-widget";
 import PluginOutlet from "discourse/components/plugin-outlet";
+import Post from "discourse/components/post";
 import icon from "discourse/helpers/d-icon";
 import htmlSafe from "discourse/helpers/html-safe";
 import discourseDebounce from "discourse/lib/debounce";
@@ -72,8 +73,11 @@ export default class DocsTopic extends Component {
     <div class="topic-content">
       <h1>{{htmlSafe this.topic.fancyTitle}}</h1>
 
-      {{! template-lint-disable no-capital-arguments }}
-      <MountWidget @widget="post" @model={{this.model}} @args={{this.post}} />
+      {{#if this.site.useGlimmerPostStream}}
+        <Post @post={{this.model}} />
+      {{else}}
+        <MountWidget @widget="post" @model={{this.model}} @args={{this.post}} />
+      {{/if}}
     </div>
 
     <a class="docs-nav-link more" href="/t/{{this.topic.id}}">

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -6,7 +6,7 @@ describe Docs do
   fab!(:category)
   fab!(:topic) { Fabricate(:topic, category: category) }
   fab!(:post) { Fabricate(:post, topic: topic) }
-  fab!(:non_docs_category) { Fabricate(:category) }
+  fab!(:non_docs_category, :category)
   fab!(:non_docs_topic) { Fabricate(:topic, category: non_docs_category) }
   fab!(:non_docs_post) { Fabricate(:post, topic: non_docs_topic) }
 

--- a/test/javascripts/acceptance/docs-user-status-test.js
+++ b/test/javascripts/acceptance/docs-user-status-test.js
@@ -11,6 +11,7 @@ acceptance("Docs - user status", function (needs) {
   needs.site({ docs_path: "docs" });
   needs.settings({
     docs_enabled: true,
+    enable_user_status: true,
   });
 
   const mentionedUserId = 1;


### PR DESCRIPTION
Updated the `docs-topic` component to leverage the `Post` component when `useGlimmerPostStream` is enabled.

Enhanced test configurations to include `enable_user_status` and adjusted factory setup in specs for consistency.