### PR TITLE
DEV: Refactor filter expansion logic in `docs-index` for desktop view

### DIFF
--- a/assets/javascripts/discourse/controllers/docs-index.js
+++ b/assets/javascripts/discourse/controllers/docs-index.js
@@ -58,7 +58,7 @@ export default class DocsIndexController extends Controller {
 
   @on("init")
   _setupFilters() {
-    if (!this.site.mobileView) {
+    if (this.site.desktopView) {
       this.set("expandedFilters", true);
     }
     this.setProperties({


### PR DESCRIPTION
Mofified the `docs-index` controller logic to expand filters only in desktop view by replacing `!this.site.mobileView` with `this.site.desktopView`.