### PR TITLE
DEV: Replace `findBy` with `find` in category lookups

### DIFF
--- a/assets/javascripts/discourse/components/docs-category.gjs
+++ b/assets/javascripts/discourse/components/docs-category.gjs
@@ -8,7 +8,7 @@ import discourseComputed from "discourse/lib/decorators";
 export default class DocsCategory extends Component {
   @discourseComputed("category")
   categoryName(category) {
-    return this.site.categories.findBy("id", category.id).name;
+    return this.site.categories.find((item) => item.id === category.id)?.name;
   }
 
   <template>

--- a/assets/javascripts/discourse/controllers/docs-index.js
+++ b/assets/javascripts/discourse/controllers/docs-index.js
@@ -81,9 +81,11 @@ export default class DocsIndexController extends Controller {
     } else {
       categories = categories.sort((a, b) => {
         const first = this.site.categories
-            .findBy("id", a.id)
+            .find((item) => item.id === a.id)
             .name.toLowerCase(),
-          second = this.site.categories.findBy("id", b.id).name.toLowerCase();
+          second = this.site.categories
+            .find((item) => item.id === b.id)
+            ?.name.toLowerCase();
         return first.localeCompare(second);
       });
     }
@@ -94,7 +96,9 @@ export default class DocsIndexController extends Controller {
 
     if (this.showCategoryFilter) {
       return categories.filter((category) => {
-        let categoryData = this.site.categories.findBy("id", category.id);
+        let categoryData = this.site.categories.find(
+          (item) => item.id === category.id
+        );
         return (
           categoryData.name.toLowerCase().indexOf(filter.toLowerCase()) > -1 ||
           (categoryData.description_excerpt &&
@@ -278,7 +282,10 @@ export default class DocsIndexController extends Controller {
 
     return this.siteSettings.docs_categories
       .split("|")
-      .map((c) => this.site.categories.findBy("id", parseInt(c, 10))?.name)
+      .map(
+        (c) =>
+          this.site.categories.find((item) => item.id === parseInt(c, 10))?.name
+      )
       .filter(Boolean);
   }
 

--- a/assets/javascripts/discourse/routes/docs-index.js
+++ b/assets/javascripts/discourse/routes/docs-index.js
@@ -29,10 +29,9 @@ export default class DocsIndex extends DiscourseRoute {
     const pageTitle = i18n("docs.title");
     if (model.topic.title && model.topic.category_id) {
       const title = model.topic.unicode_title || model.topic.title;
-      const categoryName = this.site.categories.findBy(
-        "id",
-        model.topic.category_id
-      ).name;
+      const categoryName = this.site.categories.find(
+        (item) => item.id === model.topic.category_id
+      )?.name;
       return `${title} - ${categoryName} - ${pageTitle}`;
     } else {
       return pageTitle;


### PR DESCRIPTION
Refactor category lookups across `discourse-docs` plugin by replacing `findBy` with the native `find`, simplifying the logic and ensuring safe fallback with optional chaining (`?.name`). This improves code clarity and reduces reliance on Ember's custom utilities.

Changes cover controllers, components, and routes where category references are used. No functionality impact is expected.